### PR TITLE
Pan and zoom functionality for graph visualization 

### DIFF
--- a/block_visualizer/src/block_visualizer/block_visualizer.py
+++ b/block_visualizer/src/block_visualizer/block_visualizer.py
@@ -39,7 +39,7 @@ class BlockVisualizer(VisualizerPlugin):
             function tick(e) {
                 node.attr("transform", function(d) {
                     return "translate(" + d.x + "," + d.y + ")";
-                }).call(force.drag);
+                }).call(drag);
             
                 link.attr('x1', function(d) { return d.source.x; })
                     .attr('y1', function(d) { return d.source.y; })
@@ -103,12 +103,16 @@ class BlockVisualizer(VisualizerPlugin):
                 .attr('stroke', '#000000')     
                 .attr('stroke-width', '1px')
         """ + render_direction + """
+            var drag = force.drag().on('dragstart', function() {
+                d3.event.sourceEvent.stopPropagation(); 
+            });
+    
             var node = graph.selectAll('.node')
                 .data(force.nodes()) 
                 .enter().append('g')
                 .attr('class', function(d){ return 'node id' + d.id; })
                 .on('click', function(){ nodeClick(this); })
-                .call(force.drag);
+                .call(drag);
                 
             const d3ForceKeys = new Set(['index', 'weight', 'x', 'y', 'px', 'py'])
                                 

--- a/graph_explorer/app/static/main.js
+++ b/graph_explorer/app/static/main.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+    // zoom and pan functionality
+    const svg = d3.select('#main-svg');
+    const graph = d3.select('#graph');
+
+    const zoom = d3.behavior.zoom().scaleExtent([0.1, 10]).on('zoom', function () {
+            graph.attr('transform', 'translate(' + d3.event.translate + ') scale(' + d3.event.scale + ')');
+    });
+    svg.call(zoom);
+
+    // prevent zoom and pan while dragging and dropping node
+    svg.selectAll('.node').on('mousedown.zoom', null);
+});

--- a/graph_explorer/app/static/style.css
+++ b/graph_explorer/app/static/style.css
@@ -98,7 +98,7 @@ html, body {
 .toolbar-group {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 10px;
     padding: 0 14px;
 }
 

--- a/graph_explorer/app/templates/index.html
+++ b/graph_explorer/app/templates/index.html
@@ -165,5 +165,7 @@
                 </div>
             </div>
         </div>
+        {% load static %}
+        <script src="{% static 'main.js' %}"></script>
     </body>
 </html>

--- a/graph_explorer/app/tests.py
+++ b/graph_explorer/app/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.


### PR DESCRIPTION
### What was implemented
- Fixed node dragging behavior in block visualizer by replacing `force.drag` with custom drag handler
- Added **zoom and pan functionality** for the graph using D3
- Prevented zoom triggering while dragging nodes to avoid interaction conflicts

Closes #32 