### PR TITLE
Add Simple Visualizer

### DIFF
--- a/.idea/projekat.iml
+++ b/.idea/projekat.iml
@@ -2,7 +2,13 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/api/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/block_visualizer/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/core/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/graph_explorer" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/json_data_source/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/simple_visualizer/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/xml_data_source/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.13 (graph-explorer-platform)" jdkType="Python SDK" />

--- a/simple_visualizer/pyproject.toml
+++ b/simple_visualizer/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "graph-simple-visualizer"
+version = "0.0.1"
+description = "Graph visualization plugin for simple visualization"
+dependencies = ["graph-api>=0.0.1"]
+
+[project.entry-points."graph.visualizer"]
+simple_visualizer = "simple_visualizer.simple_visualizer:SimpleVisualizer"

--- a/simple_visualizer/src/simple_visualizer/simple_visualizer.py
+++ b/simple_visualizer/src/simple_visualizer/simple_visualizer.py
@@ -1,0 +1,138 @@
+from api.model import Graph, Node, Edge
+from api.plugins import VisualizerPlugin
+import json
+
+
+class SimpleVisualizer(VisualizerPlugin):
+    def name(self) -> str:
+        return "Simple Visualizer"
+
+    def identifier(self) -> str:
+        return "simple_visualizer"
+
+    @staticmethod
+    def node_label(node: Node) -> str:
+        if node.attributes:
+            return str(next(iter(node.attributes.values())))
+        return str(node.id)[:8]
+
+    @staticmethod
+    def serialize_node(node: Node) -> str:
+        dictionary = {"id": str(node.id), "label": SimpleVisualizer.node_label(node)}
+        for attribute in node.attributes:
+            dictionary[attribute] = str(node.attributes[attribute])
+        return json.dumps(dictionary)
+
+    @staticmethod
+    def serialize_edge(edge: Edge) -> str:
+        return json.dumps({"source": str(edge.source.id), "target": str(edge.target.id)})
+
+    def render(self, graph: Graph, **kwargs) -> str:
+        node_list_js = "var nodes = {\n"
+        for node in graph.get_nodes():
+            node_list_js += f"  '{node.id}': {self.serialize_node(node)},\n"
+        node_list_js += "};\n"
+
+        edge_list_js = "var edges = [\n"
+        for edge in graph.get_edges():
+            edge_list_js += f"  {self.serialize_edge(edge)},\n"
+        edge_list_js += "];\n"
+
+        arrow_marker = """
+            d3.select("svg").append("defs").selectAll("marker")
+                .data(["arrow"])
+                .enter().append("marker")
+                .attr("id", "arrow")
+                .attr("viewBox", "0 -5 10 10")
+                .attr("refX", 28)
+                .attr("refY", 0)
+                .attr("markerWidth", 6)
+                .attr("markerHeight", 6)
+                .attr("orient", "auto")
+                .append("path")
+                .attr("d", "M0,-5L10,0L0,5");
+        """ if graph.is_directed() else ""
+
+        arrow_attr = ".attr('marker-end', 'url(#arrow)')" if graph.is_directed() else ""
+
+        d3 = f"""
+            var radius = 20;
+
+            {arrow_marker}
+
+            edges.forEach(function(edge) {{
+                edge.source = nodes[edge.source];
+                edge.target = nodes[edge.target];
+            }});
+
+            var force = d3.layout.force()
+                .size([480, 270])
+                .nodes(d3.values(nodes))
+                .links(edges)
+                .linkDistance(120)
+                .charge(-400)
+                .on("tick", tick)
+                .start();
+
+            var graphEl = d3.select("#graph");
+
+            var link = graphEl.selectAll(".link")
+                .data(edges)
+                .enter().append("line")
+                .attr("class", "link")
+                .attr("stroke", "#999")
+                .attr("stroke-width", "1.5px")
+                {arrow_attr};
+
+            var drag = force.drag().on("dragstart", function() {{
+                d3.event.sourceEvent.stopPropagation();
+            }});
+
+            var node = graphEl.selectAll(".node")
+                .data(force.nodes())
+                .enter().append("g")
+                .attr("class", function(d) {{ return "node id" + d.id; }})
+                .on("click", function() {{ nodeClick(this); }})
+                .call(drag);
+
+            node.append("circle")
+                .attr("r", radius)
+                .attr("fill", "#6baed6")
+                .attr("stroke", "#2171b5")
+                .attr("stroke-width", "1.5px");
+
+            node.append("text")
+                .attr("text-anchor", "middle")
+                .attr("dy", "0.35em")
+                .attr("font-size", "11px")
+                .attr("fill", "#fff")
+                .attr("pointer-events", "none")
+                .text(function(d) {{
+                    var label = d.label || d.id;
+                    return label.length > 10 ? label.substring(0, 10) + "..." : label;
+                }});
+
+            node.append("title")
+                .text(function(d) {{
+                    var d3Keys = new Set(["index", "weight", "x", "y", "px", "py"]);
+                    var text = "";
+                    for (var key in d) {{
+                        if (!d3Keys.has(key)) text += key + ": " + d[key] + "\\n";
+                    }}
+                    return text;
+                }});
+
+            function tick() {{
+                link
+                    .attr("x1", function(d) {{ return d.source.x; }})
+                    .attr("y1", function(d) {{ return d.source.y; }})
+                    .attr("x2", function(d) {{ return d.target.x; }})
+                    .attr("y2", function(d) {{ return d.target.y; }});
+
+                node.attr("transform", function(d) {{
+                    return "translate(" + d.x + "," + d.y + ")";
+                }});
+            }}
+        """
+
+        return "<script>\n" + node_list_js + edge_list_js + d3 + "\n</script>"

--- a/simple_visualizer/src/simple_visualizer/simple_visualizer.py
+++ b/simple_visualizer/src/simple_visualizer/simple_visualizer.py
@@ -39,24 +39,25 @@ class SimpleVisualizer(VisualizerPlugin):
         edge_list_js += "];\n"
 
         arrow_marker = """
-            d3.select("svg").append("defs").selectAll("marker")
+            d3.select("#main-svg").append("defs").selectAll("marker")
                 .data(["arrow"])
                 .enter().append("marker")
                 .attr("id", "arrow")
                 .attr("viewBox", "0 -5 10 10")
-                .attr("refX", 28)
+                .attr("refX", 34)
                 .attr("refY", 0)
                 .attr("markerWidth", 6)
                 .attr("markerHeight", 6)
                 .attr("orient", "auto")
                 .append("path")
-                .attr("d", "M0,-5L10,0L0,5");
+                .attr("d", "M0,-5L10,0L0,5")
+                .attr("fill", "#999");
         """ if graph.is_directed() else ""
 
         arrow_attr = ".attr('marker-end', 'url(#arrow)')" if graph.is_directed() else ""
 
         d3 = f"""
-            var radius = 20;
+            var radius = 32;
 
             {arrow_marker}
 
@@ -103,13 +104,22 @@ class SimpleVisualizer(VisualizerPlugin):
 
             node.append("text")
                 .attr("text-anchor", "middle")
-                .attr("dy", "0.35em")
-                .attr("font-size", "11px")
+                .attr("font-size", "10px")
                 .attr("fill", "#fff")
                 .attr("pointer-events", "none")
-                .text(function(d) {{
-                    var label = d.label || d.id;
-                    return label.length > 10 ? label.substring(0, 10) + "..." : label;
+                .each(function(d) {{
+                    var label = String(d.label || d.id);
+                    var charsPerLine = 10;
+                    var sel = d3.select(this);
+                    if (label.length <= charsPerLine) {{
+                        sel.append("tspan").attr("x", 0).attr("dy", "0.35em").text(label);
+                    }} else {{
+                        var line1 = label.substring(0, charsPerLine);
+                        var rest = label.substring(charsPerLine);
+                        var line2 = rest.length > charsPerLine ? rest.substring(0, charsPerLine - 1) + "..." : rest;
+                        sel.append("tspan").attr("x", 0).attr("dy", "-0.25em").text(line1);
+                        sel.append("tspan").attr("x", 0).attr("dy", "1.2em").text(line2);
+                    }}
                 }});
 
             node.append("title")


### PR DESCRIPTION
### What was implemented

This PR introduces a SimpleVisualizer class that generates a client-side script for rendering Graph objects.

The Graph is converted into a JavaScript representation along with embedded d3.js logic, which produces HTML SVG elements for each node and edge.

The SimpleVisualizer is designed to provide a high-level overview of the graph structure without focusing on detailed metadata.

For node labeling, the first attribute is displayed when available, otherwise, the first 8 characters of the node ID are used as the title.

Closes #34 