### PR TITLE
Tree View

### DIFF
--- a/graph_explorer/app/static/main.js
+++ b/graph_explorer/app/static/main.js
@@ -68,9 +68,62 @@ document.addEventListener('DOMContentLoaded', () => {
         const wasSelected = node.classList.contains('selected');
         document.querySelectorAll('#graph .node').forEach(n => n.classList.remove('selected'));
         if (!wasSelected) node.classList.add('selected');
-        GraphEvents.publish('node:selected', { el: node, selected: !wasSelected });
+
+        var nodeId = null;
+        node.classList.forEach(function (c) {
+            if (c !== 'node' && c !== 'selected') {
+                nodeId = c.replace(/^id/, '');
+            }
+        });
+
+        GraphEvents.publish('node:selected', {el: node, id: nodeId, selected: !wasSelected});
     });
 
+    // Tree View → Main View
+    // When a node is selected in Tree View, highlight it and pan Main View to centre on it.
+    GraphEvents.subscribe('node:selected', function(data) {
+        if (data.source !== 'tree') return;
+
+        var nodeId = data.id;
+        if (!nodeId) return;
+
+        document.querySelectorAll('#graph .node').forEach(function(n) {
+            n.classList.remove('selected');
+        });
+
+        var nodeEl = document.querySelector('#graph .node[class*="' + nodeId + '"]');
+        if (!nodeEl && nodes[nodeId] && nodes[nodeId].id) {
+            var xmlId = String(nodes[nodeId].id);
+            nodeEl = document.querySelector('#graph .node[class*="' + xmlId + '"]');
+        }
+
+        if (!nodeEl) return;
+        nodeEl.classList.add('selected');
+
+        // Pan Main View to centre on the selected node.
+        var transform = nodeEl.getAttribute('transform');
+        var match = transform && transform.match(/translate\(([^,]+),([^)]+)\)/);
+        if (!match) return;
+
+        var nodeX = parseFloat(match[1]);
+        var nodeY = parseFloat(match[2]);
+
+        var mainSVG = document.getElementById('main-svg');
+        var scale = window._mainZoom.scale();
+        var newTx = mainSVG.clientWidth  / 2 - nodeX * scale;
+        var newTy = mainSVG.clientHeight / 2 - nodeY * scale;
+
+        window._mainZoom.translate([newTx, newTy]);
+        d3.select('#graph').attr('transform',
+            'translate(' + newTx + ',' + newTy + ') scale(' + scale + ')');
+
+        // Notify Bird View and any other listeners of the new pan position
+        GraphEvents.publish('graph:zoom', {
+            translate: [newTx, newTy],
+            scale: scale
+        });
+
+    });
     // Handled on mouseup, keep empty to prevent double toggle
     window.nodeClick = function (el) {};
 });

--- a/graph_explorer/app/static/style.css
+++ b/graph_explorer/app/static/style.css
@@ -394,6 +394,23 @@ select {
 
 .tree-field span { color: var(--ink); font-weight: 600; }
 
+.tree-toggle-placeholder {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
+.tree-node-header.tree-selected {
+    background: var(--highlight-bg);
+    outline: 2px solid var(--highlight);
+    outline-offset: -2px;
+}
+
+.tree-node-attrs {
+    padding-left: 30px;
+}
+
 #bird-view {
     grid-column: 1;
     grid-row: 3;

--- a/graph_explorer/app/static/style.css
+++ b/graph_explorer/app/static/style.css
@@ -411,6 +411,12 @@ select {
     padding-left: 30px;
 }
 
+.tree-node-header.selected {
+    background: var(--accent, #2171b5);
+    color: white;
+    border-radius: 4px;
+}
+
 #bird-view {
     grid-column: 1;
     grid-row: 3;

--- a/graph_explorer/app/static/treeview.js
+++ b/graph_explorer/app/static/treeview.js
@@ -33,7 +33,7 @@
 
     /** Render attribute rows for a node (non-D3 keys). */
     function renderAttributes(nodeData) {
-        var html = '';
+     var html = '';
         Object.keys(nodeData).forEach(function (key) {
             if (D3_KEYS.has(key)) return;
             html += '<div class="tree-field">' + key + ': <span>' + nodeData[key] + '</span></div>';
@@ -50,22 +50,20 @@
         var nodeData = nodes[nodeId];
         if (!nodeData) return '';
 
-        var label = nodeData.label || nodeData.name || nodeData.id || nodeId;
+        var label = nodeData.label || nodeData.name || nodeData.tag || (nodeData.id ? String(nodeData.id).substring(0, 8) : nodeId.substring(0, 8));
         var children = adj[nodeId] || [];
         var hasChildren = children.length > 0;
-
-        // Cycle: this node is already an ancestor on the path
         var isCycle = visited.has(nodeId);
         var isExpanded = expanded.has(nodeId);
 
         var toggleIcon = '';
-        if (hasChildren && !isCycle) {
-            toggleIcon = '<span class="tree-toggle">' + (isExpanded ? '−' : '+') + '</span>';
+         if (hasChildren && !isCycle) {
+            toggleIcon = '<span class="tree-toggle" data-toggle="' + nodeId + '">' + (isExpanded ? '−' : '+') + '</span>';
         } else {
             toggleIcon = '<span class="tree-toggle-placeholder"></span>';
         }
 
-        var cycleLabel = isCycle ? ' <em style="color:var(--err);font-size:10px;">[cycle]</em>' : '';
+        var cycleLabel = isCycle ? ' <em style="color:var(--err);font-size:10px;">[↩ cycle]</em>' : '';
 
         var html = '<div class="tree-node" data-node-id="' + nodeId + '">';
         html += '<div class="tree-node-header" data-node-id="' + nodeId + '">';
@@ -74,25 +72,92 @@
         html += cycleLabel;
         html += '</div>';
 
-        // Attribute fields (always visible when parent is expanded)
-        html += '<div class="tree-node-attrs" style="' + (isExpanded ? '' : 'display:none') + '">';
+        html += '<div class="tree-node-attrs" data-attrs-for="' + nodeId + '" style="' + (isExpanded ? '' : 'display:none') + '">';
         html += renderAttributes(nodeData);
         html += '</div>';
 
-        // Children container
         if (hasChildren && !isCycle && isExpanded) {
-            html += '<div class="tree-node-children">';
+            html += '<div class="tree-node-children" data-children-for="' + nodeId + '">';
             var newVisited = new Set(visited);
             newVisited.add(nodeId);
             children.forEach(function (childId) {
                 html += renderNode(childId, adj, newVisited, expanded);
             });
             html += '</div>';
+        } else if (hasChildren && !isCycle && !isExpanded) {
+            html += '<div class="tree-node-children" data-children-for="' + nodeId + '" style="display:none"></div>';
         }
 
         html += '</div>';
         return html;
     }
+
+
+    function handleToggle(nodeId, state, nodeElement) {
+        var adj = state.adj;
+        var expanded = state.expanded;
+
+        var children = adj[nodeId] || [];
+        if (children.length === 0) return;
+
+        var childrenDiv = nodeElement.querySelector('[data-children-for="' + nodeId + '"]');
+        var attrsDiv = nodeElement.querySelector('[data-attrs-for="' + nodeId + '"]');
+        var toggleBtn = nodeElement.querySelector('[data-toggle="' + nodeId + '"]');
+
+        if (expanded.has(nodeId)) {
+            expanded.delete(nodeId);
+
+            if (childrenDiv) childrenDiv.style.display = 'none';
+            if (attrsDiv) attrsDiv.style.display = 'none';
+            if (toggleBtn) toggleBtn.textContent = '+';
+
+        } else {
+            expanded.add(nodeId);
+
+            if (attrsDiv) attrsDiv.style.display = '';
+            if (toggleBtn) toggleBtn.textContent = '−';
+
+            if (childrenDiv) {
+                childrenDiv.style.display = '';
+
+                if (childrenDiv.children.length === 0) {
+
+                    var visited = new Set();
+                    var el = nodeElement;
+                    while (el) {
+                        var pid = el.getAttribute('data-node-id');
+                        if (pid) visited.add(pid);
+                        el = el.parentElement.closest('.tree-node');
+                    }
+
+                    var html = '';
+                    children.forEach(function (childId) {
+                        html += renderNode(childId, adj, visited, expanded);
+                    });
+
+                    childrenDiv.innerHTML = html;
+                }
+            }
+        }
+}
+
+function attachClickHandlers(state) {
+    var container = document.getElementById('tree-view-content');
+
+    container.addEventListener('click', function (e) {
+        var header = e.target.closest('.tree-node-header');
+        if (!header) return;
+
+        var nodeId = header.getAttribute('data-node-id');
+        if (!nodeId) return;
+
+        var nodeElement = header.closest('.tree-node');
+
+        handleToggle(nodeId, state, nodeElement);
+
+        GraphEvents.publish('node:selected', { id: nodeId, source: 'tree' });
+    });
+}
 
     function buildTree() {
         if (typeof nodes === 'undefined' || typeof edges === 'undefined') return;
@@ -102,20 +167,18 @@
 
         var adj = buildAdjacency(edges);
         var rootId = pickRoot(nodeIds, edges);
-
-        // Start with root expanded
         var expanded = new Set([rootId]);
+        var state = { adj: adj, rootId: rootId, expanded: expanded };
 
         var container = document.getElementById('tree-view-content');
         if (!container) return;
 
         container.innerHTML = renderNode(rootId, adj, new Set(), expanded);
+        container._treeState = state;
 
-        // Store state on container for use in later commits
-        container._treeState = { adj: adj, rootId: rootId, expanded: expanded };
-    }
+        attachClickHandlers(state);
+        }
 
-    // Expose so later commits can call rebuild
     window._treeViewBuild = buildTree;
 
 
@@ -138,10 +201,8 @@
         attributeFilter: ['transform']
     });
 
-    // Also try immediately in case graph is already rendered
     document.addEventListener('DOMContentLoaded', maybeInit);
 
-    // Re-build on graph reset
     GraphEvents.subscribe('graph:reset', function () {
         initDone = false;
         var container = document.getElementById('tree-view-content');

--- a/graph_explorer/app/static/treeview.js
+++ b/graph_explorer/app/static/treeview.js
@@ -1,0 +1,151 @@
+(function () {
+
+    /** Build adjacency list: nodeId → [nodeId, ...] from the global `edges` array. */
+    function buildAdjacency(edgesArr) {
+        var adj = {};
+        Object.keys(nodes).forEach(function (id) { adj[id] = []; });
+        edgesArr.forEach(function (edge) {
+            var srcId = typeof edge.source === 'object' ? edge.source.id : edge.source;
+            var tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target;
+            if (srcId && tgtId) {
+                if (!adj[srcId]) adj[srcId] = [];
+                adj[srcId].push(tgtId);
+            }
+        });
+        return adj;
+    }
+
+    /** Pick root = node with no incoming edges (or first node as fallback). */
+    function pickRoot(nodeIds, edgesArr) {
+        var hasIncoming = {};
+        edgesArr.forEach(function (edge) {
+            var tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target;
+            if (tgtId) hasIncoming[tgtId] = true;
+        });
+        for (var i = 0; i < nodeIds.length; i++) {
+            if (!hasIncoming[nodeIds[i]]) return nodeIds[i];
+        }
+        return nodeIds[0];
+    }
+
+    /** D3-force keys we don't want to display as attributes. */
+    var D3_KEYS = new Set(['index', 'weight', 'x', 'y', 'px', 'py', 'id', 'label']);
+
+    /** Render attribute rows for a node (non-D3 keys). */
+    function renderAttributes(nodeData) {
+        var html = '';
+        Object.keys(nodeData).forEach(function (key) {
+            if (D3_KEYS.has(key)) return;
+            html += '<div class="tree-field">' + key + ': <span>' + nodeData[key] + '</span></div>';
+        });
+        return html;
+    }
+
+    /**
+     * Recursively build HTML for a tree node.
+     * visited  – Set of ids already on the current path (cycle detection).
+     * expanded – Set of ids that are currently open.
+     */
+    function renderNode(nodeId, adj, visited, expanded) {
+        var nodeData = nodes[nodeId];
+        if (!nodeData) return '';
+
+        var label = nodeData.label || nodeData.name || nodeData.id || nodeId;
+        var children = adj[nodeId] || [];
+        var hasChildren = children.length > 0;
+
+        // Cycle: this node is already an ancestor on the path
+        var isCycle = visited.has(nodeId);
+        var isExpanded = expanded.has(nodeId);
+
+        var toggleIcon = '';
+        if (hasChildren && !isCycle) {
+            toggleIcon = '<span class="tree-toggle">' + (isExpanded ? '−' : '+') + '</span>';
+        } else {
+            toggleIcon = '<span class="tree-toggle-placeholder"></span>';
+        }
+
+        var cycleLabel = isCycle ? ' <em style="color:var(--err);font-size:10px;">[cycle]</em>' : '';
+
+        var html = '<div class="tree-node" data-node-id="' + nodeId + '">';
+        html += '<div class="tree-node-header" data-node-id="' + nodeId + '">';
+        html += toggleIcon;
+        html += '<span class="tree-node-label">' + label + '</span>';
+        html += cycleLabel;
+        html += '</div>';
+
+        // Attribute fields (always visible when parent is expanded)
+        html += '<div class="tree-node-attrs" style="' + (isExpanded ? '' : 'display:none') + '">';
+        html += renderAttributes(nodeData);
+        html += '</div>';
+
+        // Children container
+        if (hasChildren && !isCycle && isExpanded) {
+            html += '<div class="tree-node-children">';
+            var newVisited = new Set(visited);
+            newVisited.add(nodeId);
+            children.forEach(function (childId) {
+                html += renderNode(childId, adj, newVisited, expanded);
+            });
+            html += '</div>';
+        }
+
+        html += '</div>';
+        return html;
+    }
+
+    function buildTree() {
+        if (typeof nodes === 'undefined' || typeof edges === 'undefined') return;
+
+        var nodeIds = Object.keys(nodes);
+        if (nodeIds.length === 0) return;
+
+        var adj = buildAdjacency(edges);
+        var rootId = pickRoot(nodeIds, edges);
+
+        // Start with root expanded
+        var expanded = new Set([rootId]);
+
+        var container = document.getElementById('tree-view-content');
+        if (!container) return;
+
+        container.innerHTML = renderNode(rootId, adj, new Set(), expanded);
+
+        // Store state on container for use in later commits
+        container._treeState = { adj: adj, rootId: rootId, expanded: expanded };
+    }
+
+    // Expose so later commits can call rebuild
+    window._treeViewBuild = buildTree;
+
+
+    var initDone = false;
+
+    function maybeInit() {
+        if (initDone) return;
+        if (typeof nodes !== 'undefined' && Object.keys(nodes).length > 0) {
+            initDone = true;
+            buildTree();
+        }
+    }
+
+    var observer = new MutationObserver(function () {
+        maybeInit();
+    });
+    observer.observe(document.getElementById('graph'), {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['transform']
+    });
+
+    // Also try immediately in case graph is already rendered
+    document.addEventListener('DOMContentLoaded', maybeInit);
+
+    // Re-build on graph reset
+    GraphEvents.subscribe('graph:reset', function () {
+        initDone = false;
+        var container = document.getElementById('tree-view-content');
+        if (container) container.innerHTML = '';
+    });
+
+})();

--- a/graph_explorer/app/static/treeview.js
+++ b/graph_explorer/app/static/treeview.js
@@ -1,12 +1,33 @@
 (function () {
 
-    /** Build adjacency list: nodeId → [nodeId, ...] from the global `edges` array. */
+    // Builds an adjacency list from edges
     function buildAdjacency(edgesArr) {
         var adj = {};
         Object.keys(nodes).forEach(function (id) { adj[id] = []; });
+
+        var xmlIdToUuid = {};
+        Object.keys(nodes).forEach(function (uuidKey) {
+            var n = nodes[uuidKey];
+            if (n.id) {
+                xmlIdToUuid[String(n.id)] = uuidKey;
+            }
+        });
+
+        // Resolves a raw edge endpoint (UUID string or node object) to an internal UUID key
+        function resolveId(raw) {
+            var s = String(raw);
+            if (nodes[s] !== undefined) return s;
+            if (xmlIdToUuid[s] !== undefined) return xmlIdToUuid[s];
+            return null;
+        }
+
         edgesArr.forEach(function (edge) {
-            var srcId = typeof edge.source === 'object' ? edge.source.id : edge.source;
-            var tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target;
+            var srcRaw = typeof edge.source === 'object' ? edge.source.id : edge.source;
+            var tgtRaw = typeof edge.target === 'object' ? edge.target.id : edge.target;
+
+            var srcId = resolveId(srcRaw);
+            var tgtId = resolveId(tgtRaw);
+
             if (srcId && tgtId) {
                 if (!adj[srcId]) adj[srcId] = [];
                 adj[srcId].push(tgtId);
@@ -15,25 +36,28 @@
         return adj;
     }
 
-    /** Pick root = node with no incoming edges (or first node as fallback). */
+    // Picks the root node: prefers a node with no incoming edges (true root).
+    // Falls back to the first node if the graph is fully cyclic.
     function pickRoot(nodeIds, edgesArr) {
         var hasIncoming = {};
         edgesArr.forEach(function (edge) {
-            var tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target;
-            if (tgtId) hasIncoming[tgtId] = true;
+            var tgtRaw = typeof edge.target === 'object' ? edge.target.id : edge.target;
+            if (tgtRaw) hasIncoming[String(tgtRaw)] = true;
         });
         for (var i = 0; i < nodeIds.length; i++) {
-            if (!hasIncoming[nodeIds[i]]) return nodeIds[i];
+            var n = nodes[nodeIds[i]];
+            var xmlId = n && n.id ? String(n.id) : nodeIds[i];
+            if (!hasIncoming[nodeIds[i]] && !hasIncoming[xmlId]) return nodeIds[i];
         }
         return nodeIds[0];
     }
 
-    /** D3-force keys we don't want to display as attributes. */
-    var D3_KEYS = new Set(['index', 'weight', 'x', 'y', 'px', 'py', 'id', 'label']);
+    // Keys added by D3 force layout — excluded from attribute display
+    var D3_KEYS = new Set(['index', 'weight', 'x', 'y', 'px', 'py', 'id', 'label', 'tag']);
 
-    /** Render attribute rows for a node (non-D3 keys). */
+    // Renders key-value attribute rows for a node, skipping internal D3 keys
     function renderAttributes(nodeData) {
-     var html = '';
+        var html = '';
         Object.keys(nodeData).forEach(function (key) {
             if (D3_KEYS.has(key)) return;
             html += '<div class="tree-field">' + key + ': <span>' + nodeData[key] + '</span></div>';
@@ -41,23 +65,35 @@
         return html;
     }
 
-    /**
-     * Recursively build HTML for a tree node.
-     * visited  – Set of ids already on the current path (cycle detection).
-     * expanded – Set of ids that are currently open.
-     */
+    // Recursively renders a tree node as HTML.
+    // Shows [cycle] and disables expansion when a cycle is detected via `visited`.
+    // A node gets a "+" toggle if it has children OR displayable attributes.
     function renderNode(nodeId, adj, visited, expanded) {
         var nodeData = nodes[nodeId];
         if (!nodeData) return '';
 
-        var label = nodeData.label || nodeData.name || nodeData.tag || (nodeData.id ? String(nodeData.id).substring(0, 8) : nodeId.substring(0, 8));
+        var label = nodeData.label
+            || nodeData.full_name
+            || nodeData.name
+            || nodeData.model
+            || nodeData.tag
+            || nodeId.substring(0, 8);
+
         var children = adj[nodeId] || [];
-        var hasChildren = children.length > 0;
         var isCycle = visited.has(nodeId);
         var isExpanded = expanded.has(nodeId);
 
+        var displayAttrs = Object.keys(nodeData).filter(function(k) {
+            return !D3_KEYS.has(k);
+        });
+
+        var hasChildren = children.length > 0;
+        var hasAttrs = displayAttrs.length > 0;
+        // Node is expandable if it has children or attributes, and is not a cycle back-edge
+        var canExpand = (hasChildren || hasAttrs) && !isCycle;
+
         var toggleIcon = '';
-         if (hasChildren && !isCycle) {
+        if (canExpand) {
             toggleIcon = '<span class="tree-toggle" data-toggle="' + nodeId + '">' + (isExpanded ? '−' : '+') + '</span>';
         } else {
             toggleIcon = '<span class="tree-toggle-placeholder"></span>';
@@ -92,13 +128,18 @@
         return html;
     }
 
-
+    // Handles expand/collapse toggle for a node.
     function handleToggle(nodeId, state, nodeElement) {
         var adj = state.adj;
         var expanded = state.expanded;
 
         var children = adj[nodeId] || [];
-        if (children.length === 0) return;
+        var nodeData = nodes[nodeId];
+        var displayAttrs = nodeData ? Object.keys(nodeData).filter(function(k) {
+            return !D3_KEYS.has(k);
+        }) : [];
+
+        if (children.length === 0 && displayAttrs.length === 0) return;
 
         var childrenDiv = nodeElement.querySelector('[data-children-for="' + nodeId + '"]');
         var attrsDiv = nodeElement.querySelector('[data-attrs-for="' + nodeId + '"]');
@@ -106,14 +147,11 @@
 
         if (expanded.has(nodeId)) {
             expanded.delete(nodeId);
-
             if (childrenDiv) childrenDiv.style.display = 'none';
             if (attrsDiv) attrsDiv.style.display = 'none';
             if (toggleBtn) toggleBtn.textContent = '+';
-
         } else {
             expanded.add(nodeId);
-
             if (attrsDiv) attrsDiv.style.display = '';
             if (toggleBtn) toggleBtn.textContent = '−';
 
@@ -121,7 +159,6 @@
                 childrenDiv.style.display = '';
 
                 if (childrenDiv.children.length === 0) {
-
                     var visited = new Set();
                     var el = nodeElement;
                     while (el) {
@@ -134,34 +171,28 @@
                     children.forEach(function (childId) {
                         html += renderNode(childId, adj, visited, expanded);
                     });
-
                     childrenDiv.innerHTML = html;
                 }
             }
         }
-}
+    }
 
-function attachClickHandlers(state) {
-    var container = document.getElementById('tree-view-content');
-
-    container.addEventListener('click', function (e) {
-        var header = e.target.closest('.tree-node-header');
-        if (!header) return;
-
-        var nodeId = header.getAttribute('data-node-id');
-        if (!nodeId) return;
-
-        var nodeElement = header.closest('.tree-node');
-
-        handleToggle(nodeId, state, nodeElement);
-
-        GraphEvents.publish('node:selected', { id: nodeId, source: 'tree' });
-    });
-}
+    // Attaches a single delegated click listener to the tree container.
+    function attachClickHandlers(state) {
+        var container = document.getElementById('tree-view-content');
+        container.addEventListener('click', function (e) {
+            var header = e.target.closest('.tree-node-header');
+            if (!header) return;
+            var nodeId = header.getAttribute('data-node-id');
+            if (!nodeId) return;
+            var nodeElement = header.closest('.tree-node');
+            handleToggle(nodeId, state, nodeElement);
+            GraphEvents.publish('node:selected', { id: nodeId, source: 'tree' });
+        });
+    }
 
     function buildTree() {
         if (typeof nodes === 'undefined' || typeof edges === 'undefined') return;
-
         var nodeIds = Object.keys(nodes);
         if (nodeIds.length === 0) return;
 
@@ -174,13 +205,12 @@ function attachClickHandlers(state) {
         if (!container) return;
 
         container.innerHTML = renderNode(rootId, adj, new Set(), expanded);
+        // Store state on the DOM element so subscribers can access it
         container._treeState = state;
-
         attachClickHandlers(state);
-        }
+    }
 
     window._treeViewBuild = buildTree;
-
 
     var initDone = false;
 
@@ -192,13 +222,9 @@ function attachClickHandlers(state) {
         }
     }
 
-    var observer = new MutationObserver(function () {
-        maybeInit();
-    });
+    var observer = new MutationObserver(function () { maybeInit(); });
     observer.observe(document.getElementById('graph'), {
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['transform']
+        subtree: true, attributes: true, attributeFilter: ['transform']
     });
 
     document.addEventListener('DOMContentLoaded', maybeInit);
@@ -209,4 +235,103 @@ function attachClickHandlers(state) {
         if (container) container.innerHTML = '';
     });
 
+    // BFS from root to find the path to a target node.
+    // Used to open all ancestor nodes when navigating from Main View.
+    function findPathToNode(targetUuid, adj, rootId) {
+        var queue = [[rootId, [rootId]]];
+        var visited = new Set();
+        while (queue.length > 0) {
+            var current = queue.shift();
+            var nodeId = current[0];
+            var path = current[1];
+            if (nodeId === targetUuid) return path;
+            if (visited.has(nodeId)) continue;
+            visited.add(nodeId);
+            var children = adj[nodeId] || [];
+            children.forEach(function(childId) {
+                if (!visited.has(childId)) {
+                    queue.push([childId, path.concat(childId)]);
+                }
+            });
+        }
+        return null;
+    }
+
+    // Main View → Tree View
+    // When a node is selected in Main View, open all ancestors and scroll to it.
+    GraphEvents.subscribe('node:selected', function(data) {
+        if (data.source === 'tree') return;
+
+        var nodeId = data.id;
+        if (!nodeId) return;
+
+        document.querySelectorAll('#tree-view-content .tree-node-header')
+            .forEach(function(h) { h.classList.remove('tree-selected'); });
+
+        var targetUuid = null;
+        if (nodes[nodeId]) {
+            targetUuid = nodeId;
+        } else {
+            Object.keys(nodes).forEach(function(uuid) {
+                if (String(nodes[uuid].id) === String(nodeId)) targetUuid = uuid;
+            });
+        }
+        if (!targetUuid) return;
+
+        var container = document.getElementById('tree-view-content');
+        var state = container._treeState;
+        if (!state) return;
+
+        var path = findPathToNode(targetUuid, state.adj, state.rootId);
+        if (!path) return;
+
+        // Open each ancestor along the path (excluding the target itself)
+        path.slice(0, -1).forEach(function(ancestorId) {
+            if (!state.expanded.has(ancestorId)) {
+                state.expanded.add(ancestorId);
+                var ancestorEl = container.querySelector('.tree-node[data-node-id="' + ancestorId + '"]');
+                if (ancestorEl) {
+                    var childrenDiv = ancestorEl.querySelector('[data-children-for="' + ancestorId + '"]');
+                    var attrsDiv = ancestorEl.querySelector('[data-attrs-for="' + ancestorId + '"]');
+                    var toggleBtn = ancestorEl.querySelector('[data-toggle="' + ancestorId + '"]');
+                    if (attrsDiv) attrsDiv.style.display = '';
+                    if (toggleBtn) toggleBtn.textContent = '−';
+                    if (childrenDiv) {
+                        childrenDiv.style.display = '';
+                        if (childrenDiv.children.length === 0) {
+                            var visited = new Set();
+                            var el = ancestorEl;
+                            while (el) {
+                                var pid = el.getAttribute('data-node-id');
+                                if (pid) visited.add(pid);
+                                el = el.parentElement ? el.parentElement.closest('.tree-node') : null;
+                            }
+                            var html = '';
+                            (state.adj[ancestorId] || []).forEach(function(childId) {
+                                html += renderNode(childId, state.adj, visited, state.expanded);
+                            });
+                            childrenDiv.innerHTML = html;
+                        }
+                    }
+                }
+            }
+        });
+
+        state.expanded.add(targetUuid);
+
+        setTimeout(function() {
+            var header = container.querySelector('.tree-node-header[data-node-id="' + targetUuid + '"]');
+            if (header) {
+                header.classList.add('tree-selected');
+                header.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                var nodeEl = header.closest('.tree-node');
+                if (nodeEl) {
+                    var attrsDiv = nodeEl.querySelector('[data-attrs-for="' + targetUuid + '"]');
+                    var toggleBtn = nodeEl.querySelector('[data-toggle="' + targetUuid + '"]');
+                    if (attrsDiv) attrsDiv.style.display = '';
+                    if (toggleBtn) toggleBtn.textContent = '−';
+                }
+            }
+        }, 50);
+    });
 })();

--- a/graph_explorer/app/templates/index.html
+++ b/graph_explorer/app/templates/index.html
@@ -157,6 +157,7 @@
         </div>
         {% load static %}
         <script src="{% static 'birdview.js' %}"></script>
+        <script src="{% static 'treeview.js' %}"></script>
         <script src="{% static 'main.js' %}"></script>
         <script src="{% static 'cli.js' %}"></script>
         <script src="{% static 'toolbar.js' %}"></script>

--- a/xml_data_source/src/xml_data_source/xml_data_source.py
+++ b/xml_data_source/src/xml_data_source/xml_data_source.py
@@ -14,11 +14,13 @@ class XmlDataSource(DataSourcePlugin):
     def identifier(self) -> str:
         return "xml_data_source"
 
-    def fields(self) -> Dict[str,str]:
-        return {"directed": "checkbox",
-                "file_path": "text",
-                "reference_source_attr":"text",
-                "reference_target_attrs":"text"}
+    def fields(self) -> Dict[str, str]:
+        return {
+            "directed": "checkbox",
+            "file_path": "text",
+            "reference_source_attr": "text",
+            "reference_target_attrs": "text"
+        }
 
     def load(self, **kwargs) -> Graph:
         file_path: str = kwargs.get("file_path")
@@ -27,11 +29,9 @@ class XmlDataSource(DataSourcePlugin):
 
         directed: bool = kwargs.get("directed", False)
 
-        reference_source_attr: str = kwargs.get("reference_source_attr", "id")
-        reference_target_attrs: List[str] = kwargs.get(
-            "reference_target_attrs",
-            ["reportsTo", "assignedProject", "assignedTo"]
-        )
+        reference_source_attr: str = kwargs.get("reference_source_attr") or "id"
+        reference_target_attrs_raw: str = kwargs.get("reference_target_attrs") or "reportsTo,assignedProject,assignedTo"
+        reference_target_attrs: List[str] = [x.strip() for x in reference_target_attrs_raw.split(",")]
 
         graph = Graph(directed=directed)
         id_to_node: Dict[str, Node] = {}
@@ -58,10 +58,15 @@ class XmlDataSource(DataSourcePlugin):
             id_to_node: Dict[str, Node],
             parent_node: Optional[Node] = None,
             relation: Optional[str] = None,
-    ) -> Node:
+    ) -> Optional[Node]:
+
+        if len(element) == 0:
+            if parent_node is not None and element.text and element.text.strip():
+                parsed_value = self.parse_attribute_value(element.text.strip())
+                parent_node.add_attribute(element.tag, parsed_value)
+            return None
 
         node = Node()
-
         node.add_attribute("tag", element.tag)
 
         element_id = element.attrib.get("id")
@@ -79,12 +84,6 @@ class XmlDataSource(DataSourcePlugin):
             edge.add_attribute("relation", relation or element.tag)
             graph.add_edge(edge)
 
-        if element.text and element.text.strip():
-            node.add_attribute(
-                "text",
-                self.parse_attribute_value(element.text.strip())
-            )
-
         for child in element:
             self.parse_element(child, graph, id_to_node, node, child.tag)
 
@@ -98,9 +97,7 @@ class XmlDataSource(DataSourcePlugin):
             source_attr: str,
             target_attrs: List[str],
     ):
-
         for element in root.iter():
-
             source_id = element.attrib.get(source_attr)
             if not source_id:
                 continue


### PR DESCRIPTION
### What was implemented

- Added Tree View component that renders the graph as a hierarchical tree starting from a root node (selected as the node with no incoming edges, falling back to the first node if the graph is fully cyclic)
- Implemented dynamic expand/collapse of nodes using + / − toggles, similar to a package explorer in modern IDEs
- Children are rendered lazily — only when a node is first expanded, keeping initial render fast for large graphs
- Cycle detection via a visited Set prevents infinite recursion; cyclic back-edges are marked with a [↩ cycle] indicator
- Node attributes are displayed inline on expand, with internal D3 keys (x, y, index, etc.) filtered out
- Tree structure is derived from the active graph model (works with any data source — XML, JSON, CSV, etc.)
- Cross-view synchronization implemented using the GraphEvents observer system:
        - Selecting a node in Tree View highlights it in Main View and Bird View, and pans Main View to centre on it
        - Selecting a node in Main View opens all ancestor nodes along the path (BFS), scrolls Tree View to the node, and highlights it
-Tree View automatically rebuilds on graph reset (new data source or visualizer change)

Closes #44 